### PR TITLE
Export `anchors` or allow `anchor: Anchor | number` for cleaner expressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ebox",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ebox",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "expression-globals-typescript": "^3.2.6"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,16 +10,19 @@ const thisLayer = new Layer();
 const thisProperty = new PathProperty([[0, 0]]);
 
 // eBox types
-type Anchor =
-  | 'topLeft'
-  | 'topCenter'
-  | 'topRight'
-  | 'bottomRight'
-  | 'bottomCenter'
-  | 'bottomLeft'
-  | 'centerLeft'
-  | 'center'
-  | 'centerRight';
+const anchors = [
+  'topLeft',
+  'topCenter',
+  'topRight',
+  'bottomRight',
+  'bottomCenter',
+  'bottomLeft',
+  'centerLeft',
+  'center',
+  'centerRight',
+] as const;
+
+type Anchor = typeof anchors[number];
 
 type Rounding = [number, number, number, number];
 
@@ -302,4 +305,4 @@ function createBox({
 
 const version: string = '_npmVersion';
 
-export { createBox, version };
+export { createBox, anchors, version };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,26 +10,23 @@ const thisLayer = new Layer();
 const thisProperty = new PathProperty([[0, 0]]);
 
 // eBox types
-const anchors = [
-  'topLeft',
-  'topCenter',
-  'topRight',
-  'bottomRight',
-  'bottomCenter',
-  'bottomLeft',
-  'centerLeft',
-  'center',
-  'centerRight',
-] as const;
-
-type Anchor = typeof anchors[number];
+type Anchor =
+  | 'topLeft'
+  | 'topCenter'
+  | 'topRight'
+  | 'bottomRight'
+  | 'bottomCenter'
+  | 'bottomLeft'
+  | 'centerLeft'
+  | 'center'
+  | 'centerRight';
 
 type Rounding = [number, number, number, number];
 
 interface BoxProps {
   size: Vector2D;
   position: Vector2D;
-  anchor: Anchor;
+  anchor: Anchor | number;
   isClosed: boolean;
   rounding: Rounding;
   tangentMult: number;
@@ -44,6 +41,8 @@ function createBox({
   // From https://spencermortensen.com/articles/bezier-circle/
   tangentMult = 0.55,
 }: BoxProps) {
+  anchor = resolveAnchor(anchor);
+  
   const tempPoints = sizeToPoints(size);
   const centerPosition = anchorPositionToCenterPosition(position, size, anchor);
   const centeredPoints = movePoints(tempPoints, [0, 0], centerPosition);
@@ -301,8 +300,44 @@ function createBox({
   function pointsToComp(points: Points): Points {
     return points.map((point): Vector2D => thisLayer.fromComp(point)) as Points;
   }
+
+  function resolveAnchor(anchor: Anchor | number): Anchor {
+    const anchors = [
+      'topLeft',
+      'topCenter',
+      'topRight',
+      'bottomRight',
+      'bottomCenter',
+      'bottomLeft',
+      'centerLeft',
+      'center',
+      'centerRight',
+    ] as Anchor[];
+
+    if (typeof anchor === 'number') {
+      const resolvedAnchor = anchors[anchor - 1];
+
+      if (!resolvedAnchor) {
+        throw new Error(
+          `'${anchor}' is not a valid anchor index. Must be in range: 1-${anchors.length}`
+        );
+      }
+
+      return resolvedAnchor;
+    }
+
+    if (!anchors.includes(anchor)) {
+      throw new Error(
+        `'${anchor}' is not a valid anchor. Must be one of: ${anchors.join(
+          ', '
+        )}`
+      );
+    }
+
+    return anchor;
+  }
 }
 
 const version: string = '_npmVersion';
 
-export { createBox, anchors, version };
+export { createBox, version };


### PR DESCRIPTION
Say you have a `Dropdown Menu Control` to select the anchor for your eBox. As of now, after you create your control you'll have to derive the value like so:

```js
const { createBox } = footage('eBox.jsx').sourceData;

const anchor = [
  'topLeft',
  'topCenter',
  'topRight',
  'bottomRight',
  'bottomCenter',
  'bottomLeft',
  'centerLeft',
  'center',
  'centerRight',
][effect("Anchor")(1) - 1];

const box = createBox({
  size: [800, 200],
  position: [960, 540],
  rounding: [12, 12, 12, 12],
  anchor: anchor,
});

box.getPath();
```

But! Imagine a world where you could:

```js
const { createBox, anchors } = footage('eBox.jsx').sourceData;

const box = createBox({
  size: [800, 200],
  position: [960, 540],
  rounding: [12, 12, 12, 12],
  anchor: anchors[effect("Anchor")(1) - 1],
});

box.getPath();
```

> https://github.com/fartinmartin/eBox/commit/5b1305e01d43fab455733ecf17577dbe65a543bb

----

Or, if it doesn't make sense to export `anchors`, alternatively `anchor` could accept a number as well:

```js
const { createBox } = footage('eBox.jsx').sourceData;

const box = createBox({
  size: [800, 200],
  position: [960, 540],
  rounding: [12, 12, 12, 12],
  anchor: effect("Anchor")(1).value,
});

box.getPath();
```

> https://github.com/fartinmartin/eBox/commit/4486eb61d9112f8626ce33b9df7eb58e26a74860

----

Note: when testing `center[Left|Right]` anchors you'll run into #4